### PR TITLE
reset InvoiceService properties after save

### DIFF
--- a/src/Services/InvoiceService.php
+++ b/src/Services/InvoiceService.php
@@ -75,6 +75,8 @@ class InvoiceService implements InvoiceServiceInterface
 			]);
 		}
 
+		$this->resetInvoiceService();
+
 		return $invoice;
 	}
 
@@ -204,26 +206,26 @@ class InvoiceService implements InvoiceServiceInterface
 		return $this;
 	}
 
-  public function addNote(string $note): InvoiceService
-  {
-    $this->note = $note;
+	public function addNote(string $note): InvoiceService
+	{
+		$this->note = $note;
 
-    return $this;
-  }
+		return $this;
+	}
 
-  public function view(Invoice $invoice, array $data = []): \Illuminate\Contracts\View\View
-  {
-      return View::make('laravel-invoice::invoices.invoice', array_merge($data, [
-          'invoice' => $invoice,
-      ]));
-  }
+	public function view(Invoice $invoice, array $data = []): \Illuminate\Contracts\View\View
+	{
+		return View::make('laravel-invoice::invoices.invoice', array_merge($data, [
+			'invoice' => $invoice,
+		]));
+	}
 
-  public function saveAndView(array $data = []): \Illuminate\Contracts\View\View
-  {
-    $invoice = $this->save();
+	public function saveAndView(array $data = []): \Illuminate\Contracts\View\View
+	{
+		$invoice = $this->save();
 
-    return $this->view($invoice);
-  }
+		return $this->view($invoice);
+	}
 
 	protected function parseAddress($type, $address): array
 	{
@@ -269,5 +271,19 @@ class InvoiceService implements InvoiceServiceInterface
 		}
 
 		return $amount;
+	}
+
+	protected function resetInvoiceService()
+	{
+		$this->customer = null;
+		$this->invoiceable = null;
+		$this->number = null;
+		$this->currency = null;
+		$this->date = null;
+		$this->lines = array();
+		$this->billingAddress = array();
+		$this->shippingAddress = array();
+		$this->customFields = array();
+		$this->note = null;
 	}
 }

--- a/tests/Unit/InvoiceTest.php
+++ b/tests/Unit/InvoiceTest.php
@@ -302,4 +302,29 @@ class InvoiceTest extends TestCase
 
 		$this->assertSame('This is a note for the invoice', $invoice->note);
     }
+
+    /** @test */
+    public function invoice_services_properties_are_reseted_after_save()
+    {
+    	$invoice = CreateInvoice::for($this->customer, $this->invoiceable);
+		$invoice->invoiceNumber('INVOICE-1234');
+		$invoice->addNote('This is a note for the invoice');
+		$invoice->customField('Origin', 'Houston');
+		$invoice->invoiceLine('Some description', 1, 10000);
+		$invoice->invoiceLine('Another description', 1, 20000);
+		$invoice->fixedDiscountLine('A Cool Discout', 5000);
+		$invoice->taxLine('Tax 3%', 300);
+		$invoice->save();
+
+		$this->assertNull($invoice->customer);
+		$this->assertNull($invoice->invoiceable);
+		$this->assertNull($invoice->number);
+		$this->assertNull($invoice->currency);
+		$this->assertNull($invoice->date);
+		$this->assertNull($invoice->note);
+		$this->assertEmpty($invoice->lines);
+		$this->assertEmpty($invoice->billingAddress);
+		$this->assertEmpty($invoice->shippingAddress);
+		$this->assertEmpty($invoice->customFields);
+    }
 }


### PR DESCRIPTION
This pull request reset the InvoiceService after the save method is called.

This is made so it can be created multiple invoice as one (in a seeder for example)